### PR TITLE
Io 1091 Refactor grid so classes are generated properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+
+- Fix a bug that prevents generate certain grid classes that were extended as a placeholder.
+
 ## [1.0.1] - 03.10.2023
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [Unreleased]
 
 ### Fixed
 

--- a/src/general/grid/grid.scss
+++ b/src/general/grid/grid.scss
@@ -16,7 +16,13 @@
   }
 
   &--gap {
-    @extend %ods-grid-gap-column, %ods-grid-gap-row;
+    column-gap: grid.$gap-size-hard;
+    row-gap: grid.$gap-size-hard;
+
+    @include breakpoints.medium {
+      column-gap: grid.$gap-size-hard-large;
+      row-gap: grid.$gap-size-hard-large;
+    }
 
     &-breakpoint-medium {
       @include breakpoints.medium {
@@ -38,7 +44,11 @@
   }
 
   &--gap-column {
-    @extend %ods-grid-gap-column;
+    column-gap: grid.$gap-size-hard;
+
+    @include breakpoints.medium {
+      column-gap: grid.$gap-size-hard-large;
+    }
 
     &-breakpoint-medium {
       @include breakpoints.medium {
@@ -54,7 +64,11 @@
   }
 
   &--gap-row {
-    @extend %ods-grid-gap-row;
+    row-gap: grid.$gap-size-hard;
+
+    @include breakpoints.medium {
+      row-gap: grid.$gap-size-hard-large;
+    }
 
     &-breakpoint-medium {
       @include breakpoints.medium {
@@ -166,21 +180,5 @@
         grid-column-end: #{$i};
       }
     }
-  }
-}
-
-%ods-grid-gap-column {
-  column-gap: grid.$gap-size-hard;
-
-  @include breakpoints.medium {
-    column-gap: grid.$gap-size-hard-large;
-  }
-}
-
-%ods-grid-gap-row {
-  row-gap: grid.$gap-size-hard;
-
-  @include breakpoints.medium {
-    row-gap: grid.$gap-size-hard-large;
   }
 }

--- a/src/general/grid/grid.scss
+++ b/src/general/grid/grid.scss
@@ -17,6 +17,20 @@
 
   &--gap {
     @extend %ods-grid-gap-column, %ods-grid-gap-row;
+
+    &-breakpoint-medium {
+      @include breakpoints.medium {
+        column-gap: grid.$gap-size-hard-large;
+        row-gap: grid.$gap-size-hard-large;
+      }
+    }
+
+    &-breakpoint-large {
+      @include breakpoints.large {
+        column-gap: grid.$gap-size-hard-large;
+        row-gap: grid.$gap-size-hard-large;
+      }
+    }
   }
 
   &--dense {

--- a/src/general/grid/grid.scss
+++ b/src/general/grid/grid.scss
@@ -25,10 +25,54 @@
 
   &--gap-column {
     @extend %ods-grid-gap-column;
+
+    &-breakpoint-medium {
+      @include breakpoints.medium {
+        column-gap: grid.$gap-size-hard-large;
+      }
+    }
+
+    &-breakpoint-large {
+      @include breakpoints.large {
+        column-gap: grid.$gap-size-hard-large;
+      }
+    }
   }
 
   &--gap-row {
     @extend %ods-grid-gap-row;
+
+    &-breakpoint-medium {
+      @include breakpoints.medium {
+        row-gap: grid.$gap-size-hard-large;
+      }
+    }
+
+    &-breakpoint-large {
+      @include breakpoints.large {
+        row-gap: grid.$gap-size-hard-large;
+      }
+    }
+
+    &-large {
+      row-gap: grid.$gap-size-soft;
+
+      @include breakpoints.medium {
+        row-gap: grid.$gap-size-soft-large;
+      }
+
+      &-breakpoint-medium {
+        @include breakpoints.medium {
+          row-gap: grid.$gap-size-soft-large;
+        }
+      }
+
+      &-breakpoint-large {
+        @include breakpoints.large {
+          row-gap: grid.$gap-size-soft-large;
+        }
+      }
+    }
   }
 
   &--gutter {
@@ -117,18 +161,6 @@
   @include breakpoints.medium {
     column-gap: grid.$gap-size-hard-large;
   }
-
-  &-breakpoint-medium {
-    @include breakpoints.medium {
-      column-gap: grid.$gap-size-hard-large;
-    }
-  }
-
-  &-breakpoint-large {
-    @include breakpoints.large {
-      column-gap: grid.$gap-size-hard-large;
-    }
-  }
 }
 
 %ods-grid-gap-row {
@@ -136,37 +168,5 @@
 
   @include breakpoints.medium {
     row-gap: grid.$gap-size-hard-large;
-  }
-
-  &-breakpoint-medium {
-    @include breakpoints.medium {
-      row-gap: grid.$gap-size-hard-large;
-    }
-  }
-
-  &-breakpoint-large {
-    @include breakpoints.large {
-      row-gap: grid.$gap-size-hard-large;
-    }
-  }
-
-  &-large {
-    row-gap: grid.$gap-size-soft;
-
-    @include breakpoints.medium {
-      row-gap: grid.$gap-size-soft-large;
-    }
-
-    &-breakpoint-medium {
-      @include breakpoints.medium {
-        row-gap: grid.$gap-size-soft-large;
-      }
-    }
-
-    &-breakpoint-large {
-      @include breakpoints.large {
-        row-gap: grid.$gap-size-soft-large;
-      }
-    }
   }
 }


### PR DESCRIPTION
Etter refaktor, css viser disse klasser som mangles før:

<img width="364" alt="Screenshot 2023-10-13 at 10 40 14" src="https://github.com/oslokommune/ukeweb_designsystem/assets/37497176/563085cb-b8f7-446d-b7c2-ee5641045895">
<img width="329" alt="Screenshot 2023-10-13 at 10 40 29" src="https://github.com/oslokommune/ukeweb_designsystem/assets/37497176/3ed174bc-9a0a-4a79-8899-645f152d02e7">

