### PR TITLE
Io 1097 -  Remove border that makes component bigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+- Fixed unintended padding and border on accordion
+
 ## [1.0.1] - 03.10.2023
 
 ### Added

--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -63,7 +63,7 @@
     &:focus-visible {
       background-color: colors.$white;
       color: colors.$blue-state;
-      outline: 2px solid colors.$blue-state;
+      outline: 0.125rem solid colors.$blue-state;
     }
   }
 

--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -21,7 +21,6 @@
   &__trigger {
     @extend %ods-padding-5, %ods-padding-vertical-6-breakpoint-medium, %ods-padding-horizontal-8-breakpoint-medium;
 
-    border: 0.4rem solid transparent;
     background-color: colors.$white;
     color: colors.$blue-dark;
     display: block;
@@ -62,14 +61,9 @@
 
     &:focus-visible {
       background-color: colors.$white;
-      border: 0.2rem solid colors.$blue-state;
+      box-shadow: 0 0 0 6px solid colors.$purple-light;
+      outline: 2px solid colors.$blue-state;
       color: colors.$blue-state;
-      outline: none;
-      padding: 1.44rem;
-
-      @include breakpoints.medium {
-        padding: 1.69rem 2.19rem;
-      }
     }
   }
 

--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -63,7 +63,6 @@
     &:focus-visible {
       background-color: colors.$white;
       color: colors.$blue-state;
-      box-shadow: 0 0 0 6px colors.$purple-light;
       outline: 2px solid colors.$blue-state;
     }
   }

--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -21,6 +21,7 @@
   &__trigger {
     @extend %ods-padding-5, %ods-padding-vertical-6-breakpoint-medium, %ods-padding-horizontal-8-breakpoint-medium;
 
+    border: none;
     background-color: colors.$white;
     color: colors.$blue-dark;
     display: block;
@@ -61,9 +62,9 @@
 
     &:focus-visible {
       background-color: colors.$white;
-      box-shadow: 0 0 0 6px solid colors.$purple-light;
-      outline: 2px solid colors.$blue-state;
       color: colors.$blue-state;
+      box-shadow: 0 0 0 6px colors.$purple-light;
+      outline: 2px solid colors.$blue-state;
     }
   }
 
@@ -101,10 +102,6 @@
     @include breakpoints.medium {
       margin-right: 0.75rem;
     }
-  }
-
-  & .ods-collapsible-trigger:focus-visible::after {
-    right: 0.2rem;
   }
 
   & .ods-accordion__trigger--rotate::after {


### PR DESCRIPTION
Removes the border that should not be there, also removed padding that dynamically changed when focusing with keyboard using focus-visible.

this also adds the correct outline on keyboard focus that is being worked on in io-1022. This can be removed from this PR, however all the changes doesnt make sense if this is not included.

Not sure if this is a potential breaking change