### PR TITLE
Prevent plus/minus icon to show in other variants than filter of fieldset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added modifier to hide collapsible icon when fieldset content is empty.
+
 ## [1.0.5] - 01.11.2023
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
-- Added modifier to hide collapsible icon when fieldset content is empty.
+- Prevent plus/minus icon to show in other variants than filter.
 
 ## [1.0.5] - 01.11.2023
 

--- a/src/components/form/fieldset/fieldset.html
+++ b/src/components/form/fieldset/fieldset.html
@@ -128,9 +128,6 @@
                     </label>
                   </div>
                 </fieldset>
-                <fieldset class="ods-fieldset ods-fieldset--filter ods-fieldset--no-filter">
-                  <legend class="ods-fieldset__legend">Empty options</legend>
-                </fieldset>
               </div>
             </div>
           </div>

--- a/src/components/form/fieldset/fieldset.html
+++ b/src/components/form/fieldset/fieldset.html
@@ -316,7 +316,7 @@
             </div>
           </fieldset>
           <fieldset class="ods-fieldset ods-fieldset--filter">
-            <legend class="ods-fieldset__legend"><a href="#" class="ods-collapsible-trigger" aria-expanded="false" aria-controls="ods-fieldset--filter-1">Options</a></legend>
+            <legend class="ods-fieldset__legend"><a href="#" class="ods-collapsible-trigger" aria-expanded="false" aria-controls="ods-fieldset--filter-5">Options</a></legend>
             <div id="ods-fieldset--filter-5" class="ods-collapsible-content ods-collapsible-content--collapsed ods-collapsible-content--ease">
               <label class="ods-checkbox ods-margin-bottom-1">
                 <input type="checkbox" name="checkbox-1" checked="checked" />

--- a/src/components/form/fieldset/fieldset.html
+++ b/src/components/form/fieldset/fieldset.html
@@ -128,6 +128,9 @@
                     </label>
                   </div>
                 </fieldset>
+                <fieldset class="ods-fieldset ods-fieldset--filter ods-fieldset--no-filter">
+                  <legend class="ods-fieldset__legend">Empty options</legend>
+                </fieldset>
               </div>
             </div>
           </div>

--- a/src/components/form/fieldset/fieldset.scss
+++ b/src/components/form/fieldset/fieldset.scss
@@ -95,4 +95,14 @@
       @extend %ods-margin-bottom-0;
     }
   }
+
+  &--no-filter {
+    & .ods-fieldset__legend >*::after {
+      display: none;
+    }
+
+    & .ods-fieldset__legend > * {
+      cursor: pointer;
+    }
+  }
 }

--- a/src/components/form/fieldset/fieldset.scss
+++ b/src/components/form/fieldset/fieldset.scss
@@ -24,25 +24,7 @@
     width: 100%;
 
     > * {
-      display: block;
-      cursor: pointer;
-      position: relative;
       text-decoration: none;
-
-      &::after {
-        font-family: "Oslo Icons", Arial, Helvetica, sans-serif;
-        @extend %ods-text--size-golf;
-
-        content: map.get(icon-map.$icons, "plus-sign");
-        line-height: inherit;
-        position: absolute;
-        top: 0;
-        right: units.unit-to-rem(1);
-      }
-    }
-
-    > *.ods-collapsible-trigger--expanded::after {
-      content: map.get(icon-map.$icons, "minus-sign");
     }
   }
 
@@ -79,6 +61,29 @@
     border: none;
     border-bottom: 2px solid colors.$blue-dark;
 
+    & .ods-fieldset__legend {
+      > * {
+        display: block;
+        cursor: pointer;
+        position: relative;
+
+        &::after {
+          font-family: "Oslo Icons", Arial, Helvetica, sans-serif;
+          @extend %ods-text--size-golf;
+
+          content: map.get(icon-map.$icons, "plus-sign");
+          line-height: inherit;
+          position: absolute;
+          top: 0;
+          right: units.unit-to-rem(1);
+        }
+      }
+
+      > *.ods-collapsible-trigger--expanded::after {
+        content: map.get(icon-map.$icons, "minus-sign");
+      }
+    }
+
     > .ods-collapsible-content:first-of-type {
       @extend %ods-margin-top-3;
     }
@@ -96,13 +101,4 @@
     }
   }
 
-  &--no-filter {
-    & .ods-fieldset__legend >*::after {
-      display: none;
-    }
-
-    & .ods-fieldset__legend > * {
-      cursor: pointer;
-    }
-  }
 }


### PR DESCRIPTION
This is to prevent errors like this where the fieldset doesn't have expand/collapse functionality: 
![Screenshot 2023-11-09 at 10 51 53](https://github.com/oslokommune/ukeweb_designsystem/assets/37497176/a8e3fbbf-0c4f-44d1-9068-2d9b90d5f24d)
