### PR TITLE
io-1311: Add space between the error message and both the select and the switch components

### DIFF
--- a/src/components/form/select/select.scss
+++ b/src/components/form/select/select.scss
@@ -50,6 +50,12 @@
     }
   }
 
+  &--error {
+    .ods-select__label {
+      @extend %ods-margin-bottom-1;
+    }
+  }
+
   &__error-message {
     @include mixins.error-message;
   }

--- a/src/components/form/switch/switch.scss
+++ b/src/components/form/switch/switch.scss
@@ -68,6 +68,8 @@
   }
 
   &--error {
+    @extend %ods-margin-bottom-1;
+
     border: 2px solid colors.$red;
   }
 


### PR DESCRIPTION
https://trello.com/c/hLR72ZZk/1311-feil-spacing-mellom-komponent-og-error-message