### PR TITLE
Fixes date formatting. Adds developer tab.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed all dates to actually adhere to "Keep a changelog".
+- Fixed locale formatting for dates to adhere to UKEs writing rules.
+
+### Added
+
+- Added missing developer tab for date and time.
 
 ## [2.0.0] - 2024-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed all dates to actually adhere to "Keep a changelog".
-- Fixed locale formatting for dates to adhere to UKEs writing rules.
+- Fixed locale formatting for dates to adhere to Oslo kommunes writing rules.
 
 ### Added
 

--- a/src/general/helpers/date_and_time/date_and_time.html
+++ b/src/general/helpers/date_and_time/date_and_time.html
@@ -63,3 +63,11 @@
     </div>
   </div>
 </div>
+
+<div class="ods-devtools-devmode">
+  <div class="ods-grid">
+    <div class="ods-grid__column--12">
+      <div id="testcases"></div>
+    </div>
+  </div>
+</div>

--- a/src/general/helpers/date_and_time/date_and_time.init.js
+++ b/src/general/helpers/date_and_time/date_and_time.init.js
@@ -5,6 +5,13 @@ document.addEventListener('DOMContentLoaded', () => {
   if (testCasesElement) {
     const testCases = [
       {
+        dateFrom: new Date(2021, 1, 5, 8, 5, 32),
+        dateTo: null,
+        dateFromOptions: {},
+        dateToOptions: {},
+        toString: 'OdsDateTime.format(new Date(2021, 11, 30, 8, 5, 32))',
+      },
+      {
         dateFrom: new Date(2021, 11, 30, 8, 5, 32),
         dateTo: null,
         dateFromOptions: {},

--- a/src/general/helpers/date_and_time/date_and_time.js
+++ b/src/general/helpers/date_and_time/date_and_time.js
@@ -61,14 +61,14 @@ const OdsDateTime = {
           options.localeOptions = { hour: 'numeric', minute: 'numeric', ...options.localeOptions };
 
           if (options.type === 'to' && typeof options.prefix === 'undefined') {
-            options.prefix = '–';
+            options.prefix = '–'; // This is an em dash / mdash
           }
           break;
         case 'datetime':
           options.localeOptions = { year: 'numeric', month: '2-digit', day: '2-digit', hour: 'numeric', minute: 'numeric', ...options.localeOptions };
 
           if (options.type === 'to' && options.format === 'time' && typeof options.prefix === 'undefined') {
-            options.prefix = '–';
+            options.prefix = '–'; // This is an em dash / mdash
           }
           break;
         case 'daytime':
@@ -81,7 +81,7 @@ const OdsDateTime = {
           options.localeOptions = { year: 'numeric', month: '2-digit', day: '2-digit', ...options.localeOptions };
 
           if (options.type === 'to' && typeof options.prefix === 'undefined') {
-            options.prefix = '–';
+            options.prefix = '–'; // This is an em dash / mdash
           }
       }
     });

--- a/src/general/helpers/date_and_time/date_and_time.js
+++ b/src/general/helpers/date_and_time/date_and_time.js
@@ -46,6 +46,7 @@ const OdsDateTime = {
         hourCycle: 'h24',
         calendar: 'gregory',
         timeZone: 'Europe/Oslo',
+
       },
     };
     dateFromOptions.type = 'from';
@@ -61,14 +62,14 @@ const OdsDateTime = {
           options.localeOptions = { hour: 'numeric', minute: 'numeric', ...options.localeOptions };
 
           if (options.type === 'to' && typeof options.prefix === 'undefined') {
-            options.prefix = '&mdash;';
+            options.prefix = '–';
           }
           break;
         case 'datetime':
-          options.localeOptions = { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric', ...options.localeOptions };
+          options.localeOptions = { year: 'numeric', month: '2-digit', day: '2-digit', hour: 'numeric', minute: 'numeric', ...options.localeOptions };
 
           if (options.type === 'to' && options.format === 'time' && typeof options.prefix === 'undefined') {
-            options.prefix = '&mdash;';
+            options.prefix = '–';
           }
           break;
         case 'daytime':
@@ -78,10 +79,10 @@ const OdsDateTime = {
           options.localeOptions = { ...options.localeOptions };
           break;
         default:
-          options.localeOptions = { year: 'numeric', month: 'numeric', day: 'numeric', ...options.localeOptions };
+          options.localeOptions = { year: 'numeric', month: '2-digit', day: '2-digit', ...options.localeOptions };
 
           if (options.type === 'to' && typeof options.prefix === 'undefined') {
-            options.prefix = '&mdash;';
+            options.prefix = '–';
           }
       }
     });

--- a/src/general/helpers/date_and_time/date_and_time.js
+++ b/src/general/helpers/date_and_time/date_and_time.js
@@ -61,14 +61,14 @@ const OdsDateTime = {
           options.localeOptions = { hour: 'numeric', minute: 'numeric', ...options.localeOptions };
 
           if (options.type === 'to' && typeof options.prefix === 'undefined') {
-            options.prefix = '–'; // This is an em dash / mdash
+            options.prefix = '&ndash;';
           }
           break;
         case 'datetime':
           options.localeOptions = { year: 'numeric', month: '2-digit', day: '2-digit', hour: 'numeric', minute: 'numeric', ...options.localeOptions };
 
           if (options.type === 'to' && options.format === 'time' && typeof options.prefix === 'undefined') {
-            options.prefix = '–'; // This is an em dash / mdash
+            options.prefix = '&ndash;';
           }
           break;
         case 'daytime':
@@ -81,7 +81,7 @@ const OdsDateTime = {
           options.localeOptions = { year: 'numeric', month: '2-digit', day: '2-digit', ...options.localeOptions };
 
           if (options.type === 'to' && typeof options.prefix === 'undefined') {
-            options.prefix = '–'; // This is an em dash / mdash
+            options.prefix = '&ndash;';
           }
       }
     });

--- a/src/general/helpers/date_and_time/date_and_time.js
+++ b/src/general/helpers/date_and_time/date_and_time.js
@@ -46,7 +46,6 @@ const OdsDateTime = {
         hourCycle: 'h24',
         calendar: 'gregory',
         timeZone: 'Europe/Oslo',
-
       },
     };
     dateFromOptions.type = 'from';


### PR DESCRIPTION
Check trello card for details.

Before:

```
no-NO: 5.2.2021
en-GB: 05/02/2021
OdsDateTime.format(new Date(2021, 11, 30, 8, 5, 32))

no-NO: søndag 15.5.2022 kl. 08:00–16:00
en-GB: Sunday, 15/05/2022 at 08:00–16:00
OdsDateTime.format(new Date(2022, 4, 15, 8, 0, 0), new Date(2022, 4, 15, 16, 0, 0), {format: "datetime", time: {prefix: " kl. "}, localeOptions: {weekday: "long"}}, {format: "time"})

no-NO: 08:05—16:32
en-GB: 08:05—16:32
OdsDateTime.format(new Date(2021, 11, 30, 8, 5, 32), new Date(2021, 11, 30, 16, 32, 50), {format: "time"}, {format: "time"})
```

After:

```
no-NO: 05.02.2021
en-GB: 05/02/2021
OdsDateTime.format(new Date(2021, 11, 30, 8, 5, 32))

no-NO: søndag 15.05.2022 kl. 08:00–16:00
en-GB: Sunday, 15/05/2022 at 08:00–16:00
OdsDateTime.format(new Date(2022, 4, 15, 8, 0, 0), new Date(2022, 4, 15, 16, 0, 0), {format: "datetime", time: {prefix: " kl. "}, localeOptions: {weekday: "long"}}, {format: "time"})

no-NO: 08:05–16:32
en-GB: 08:05–16:32
OdsDateTime.format(new Date(2021, 11, 30, 8, 5, 32), new Date(2021, 11, 30, 16, 32, 50), {format: "time"}, {format: "time"})
```