### PR TITLE
IO-1317: Fix spacing on calendar icon i date component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed all dates to actually adhere to "Keep a changelog".
+- Fixed spacing on calendar icon in date component.
 
 ## [2.0.0] - 2024-05-23
 

--- a/src/components/form/date/date.scss
+++ b/src/components/form/date/date.scss
@@ -1,4 +1,5 @@
 @use "system/colors";
+@use "system/breakpoints";
 @use "system/icon-map";
 @use "system/spacing";
 @use "system/typography";
@@ -38,7 +39,11 @@
       line-height: 1em;
       position: absolute;
       right: 0.625rem;
-      bottom: 0.625rem;
+      bottom: 0.5rem;
+
+      @include breakpoints.large {
+        bottom: 0.625rem;
+      }
     }
   }
 


### PR DESCRIPTION
Vet ikke hvor lenge denne feilen har vært, eller hvor den kommer fra, men ser ut som rem-verdien ble helt feil på small og medium- Kan være jeg overså de brekkpunktene da jeg oppdaterte datepicker, eller så kommer feilene fra et annet sted jeg ikke har klart å finne.