### PR TITLE
IO-1207: add max-width to links to stop overflowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed all dates to actually adhere to "Keep a changelog".
+- Fixed an issue causing some links to not break correctly.
 
 ## [2.0.0] - 2024-05-23
 

--- a/src/components/contact/contactpoint/contactpoint.html
+++ b/src/components/contact/contactpoint/contactpoint.html
@@ -165,7 +165,7 @@
             </div>
             <div class="ods-contactpoint__group">
               <div class="ods-contactpoint__label">E-mail</div>
-              <div class="ods-contactpoint__value"><a href="javascript:void(0)" class="ods-link">i.have.a.long.name@oslo.kommune.no</a></div>
+              <div class="ods-contactpoint__value"><a href="javascript:void(0)" class="ods-link">i.have.the.longest.namewithlongerlastname@oslo.kommune.no</a></div>
             </div>
           </section>
         </div>

--- a/src/components/contact/contactpoint/contactpoint.html
+++ b/src/components/contact/contactpoint/contactpoint.html
@@ -24,7 +24,7 @@
                   </div>
                   <div class="ods-contactpoint__group">
                     <div class="ods-contactpoint__label">E-mail</div>
-                    <div class="ods-contactpoint__value"><a href="javascript:void(0)" class="ods-link">i.have.a.long.name@oslo.kommune.no</a></div>
+                    <div class="ods-contactpoint__value"><a href="javascript:void(0)" class="ods-link">i.have.the.longest.namewithlongerlastname@oslo.kommune.no</a></div>
                   </div>
                 </section>
               </div>

--- a/src/components/links/link/link.scss
+++ b/src/components/links/link/link.scss
@@ -6,6 +6,7 @@
   display: inline-block;
   text-decoration: underline;
   word-wrap: break-word;
+  max-width: 100%;
 
   @include mixins.states;
 


### PR DESCRIPTION
https://trello.com/c/65a50f0ed7de59dd4a5ddf32


Compared to display: inline, the major difference is that display: inline-block allows to set a width and height on the element.
Also, with display: inline-block, the top and bottom margins/paddings are respected, but with display: inline they are not.

Må testes grundig!!!