### PR TITLE
IO-1214: Feil i punktliste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed all dates to actually adhere to "Keep a changelog".
+- Fixed bulletpoints aligning on wrong line when they are links.
 
 ## [2.0.0] - 2024-05-23
 

--- a/src/components/links/link/link.html
+++ b/src/components/links/link/link.html
@@ -44,32 +44,6 @@
         </div>
       </div>
     </div>
-    <div class="ods-grid__column--6">
-      <h2 class="ods-devtools-text-preset-1">Bulletpoint list</h2>
-      <div class="ods-devtools-code">
-        <div class="ods-devtools-code__box">
-          <div class="ods-content">
-            <ul>
-              <li>
-                <a href="https://www.oslo.kommune.no/getfile.php/13454578-1701167665/Tjenester%20og%20tilbud/Helse%20og%20omsorg/Rusomsorg/Program%20for%20rusfeltet%20i%20Oslo%202020%20%E2%80%93%202024/Rapport%20Pers%20m%20omf.%20rus%20psyk%20og%20somatiske%20helseprobl_utvidelse%20matrise%2016.06.22.pdf" class="ods-link"
-                  >Rapport: Personer med omfattende rus-, psykiske og somatiske helseproblemer.</a
-                >
-              </li>
-              <li>
-                <a href="https://www.oslo.kommune.no/getfile.php/13454578-1701167665/Tjenester%20og%20tilbud/Helse%20og%20omsorg/Rusomsorg/Program%20for%20rusfeltet%20i%20Oslo%202020%20%E2%80%93%202024/Rapport%20Pers%20m%20omf.%20rus%20psyk%20og%20somatiske%20helseprobl_utvidelse%20matrise%2016.06.22.pdf" class="ods-link"
-                  >Rapport: Personer med omfattende rus-, psykiske og somatiske helseproblemer.</a
-                >
-              </li>
-              <li>
-                <a href="https://www.oslo.kommune.no/getfile.php/13454578-1701167665/Tjenester%20og%20tilbud/Helse%20og%20omsorg/Rusomsorg/Program%20for%20rusfeltet%20i%20Oslo%202020%20%E2%80%93%202024/Rapport%20Pers%20m%20omf.%20rus%20psyk%20og%20somatiske%20helseprobl_utvidelse%20matrise%2016.06.22.pdf" class="ods-link"
-                  >Rapport: Personer med omfattende rus-, psykiske og somatiske helseproblemer.</a
-                >
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
     <div class="ods-grid__column--12">
       <h2 class="ods-devtools-text-preset-1">No decoration</h2>
       <p class="ods-paragraph">Can be useful for standalone icons.</p>

--- a/src/components/links/link/link.html
+++ b/src/components/links/link/link.html
@@ -44,6 +44,32 @@
         </div>
       </div>
     </div>
+    <div class="ods-grid__column--6">
+      <h2 class="ods-devtools-text-preset-1">Bulletpoint list</h2>
+      <div class="ods-devtools-code">
+        <div class="ods-devtools-code__box">
+          <div class="ods-content">
+            <ul>
+              <li>
+                <a href="https://www.oslo.kommune.no/getfile.php/13454578-1701167665/Tjenester%20og%20tilbud/Helse%20og%20omsorg/Rusomsorg/Program%20for%20rusfeltet%20i%20Oslo%202020%20%E2%80%93%202024/Rapport%20Pers%20m%20omf.%20rus%20psyk%20og%20somatiske%20helseprobl_utvidelse%20matrise%2016.06.22.pdf" class="ods-link"
+                  >Rapport: Personer med omfattende rus-, psykiske og somatiske helseproblemer.</a
+                >
+              </li>
+              <li>
+                <a href="https://www.oslo.kommune.no/getfile.php/13454578-1701167665/Tjenester%20og%20tilbud/Helse%20og%20omsorg/Rusomsorg/Program%20for%20rusfeltet%20i%20Oslo%202020%20%E2%80%93%202024/Rapport%20Pers%20m%20omf.%20rus%20psyk%20og%20somatiske%20helseprobl_utvidelse%20matrise%2016.06.22.pdf" class="ods-link"
+                  >Rapport: Personer med omfattende rus-, psykiske og somatiske helseproblemer.</a
+                >
+              </li>
+              <li>
+                <a href="https://www.oslo.kommune.no/getfile.php/13454578-1701167665/Tjenester%20og%20tilbud/Helse%20og%20omsorg/Rusomsorg/Program%20for%20rusfeltet%20i%20Oslo%202020%20%E2%80%93%202024/Rapport%20Pers%20m%20omf.%20rus%20psyk%20og%20somatiske%20helseprobl_utvidelse%20matrise%2016.06.22.pdf" class="ods-link"
+                  >Rapport: Personer med omfattende rus-, psykiske og somatiske helseproblemer.</a
+                >
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="ods-grid__column--12">
       <h2 class="ods-devtools-text-preset-1">No decoration</h2>
       <p class="ods-paragraph">Can be useful for standalone icons.</p>

--- a/src/general/helpers/content/content.scss
+++ b/src/general/helpers/content/content.scss
@@ -56,6 +56,14 @@
     @extend .ods-link; /* stylelint-disable-line */
   }
 
+ // Force inline override of links in lists
+  ul li a:not(.ods-button),
+  ol li a:not(.ods-button) {
+    @extend .ods-link; /* stylelint-disable-line */
+
+    display: inline;
+  }
+
   ul {
     @extend .ods-unordered-list, %ods-margin-vertical-5; /* stylelint-disable-line */
 


### PR DESCRIPTION
Linker i punktliste fikk "doten" eller markøren sin på feil linje.

link har display: inline-block, men display: inline fikser dette problemet.

Vi kan ikke endre link til display: inline fordi dette vil dytte rundt på chevron ikoner m.m.

Derfor har jeg valgt å overstyre display spesifikt på linker i lister som brukes in ods-content.

(Dette skal først testes med september/oktober relasen før vi eventuelt tar det inn i ODS, men klargjør PR :))