### PR TITLE
IO-1344: fix outline in dropdown for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed all dates to actually adhere to "Keep a changelog".
 - Fixed locale formatting for dates to adhere to Oslo kommunes writing rules.
+- Fixed outline on dropdown elements in search and search seasons.
 
 ### Added
 

--- a/src/components/form/search/circle/circle.scss
+++ b/src/components/form/search/circle/circle.scss
@@ -191,7 +191,7 @@
       }
 
       &-last {
-        @extend %ods-margin-bottom-4;
+        @extend %ods-padding-bottom-4;
 
         &:focus-visible {
           box-shadow: 0 0 0 0.125rem colors.$blue-state;

--- a/src/components/form/search/circle/circle.scss
+++ b/src/components/form/search/circle/circle.scss
@@ -191,7 +191,13 @@
       }
 
       &-last {
-        @extend %ods-padding-bottom-4;
+        @extend %ods-margin-bottom-4;
+
+        &:focus-visible {
+          box-shadow: 0 0 0 0.125rem colors.$blue-state;
+          outline-offset: 0.125rem;
+          outline: 0.25rem solid colors.$purple-light;
+        }
       }
     }
   }
@@ -222,6 +228,12 @@
       background-color: colors.$gray-light;
       color: states.$hover;
       text-decoration: none;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 0.125rem colors.$blue-state;
+      outline-offset: 0.125rem;
+      outline: 0.25rem solid colors.$purple-light;
     }
 
     &--divider {

--- a/src/components/form/search_seasons/search_seasons.scss
+++ b/src/components/form/search_seasons/search_seasons.scss
@@ -220,7 +220,7 @@
       }
 
       &-last {
-        @extend %ods-margin-bottom-4;
+        @extend %ods-padding-bottom-4;
 
         &:focus-visible {
           box-shadow: 0 0 0 0.125rem colors.$blue-state;

--- a/src/components/form/search_seasons/search_seasons.scss
+++ b/src/components/form/search_seasons/search_seasons.scss
@@ -220,7 +220,13 @@
       }
 
       &-last {
-        @extend %ods-padding-bottom-4;
+        @extend %ods-margin-bottom-4;
+
+        &:focus-visible {
+          box-shadow: 0 0 0 0.125rem colors.$blue-state;
+          outline-offset: 0.125rem;
+          outline: 0.25rem solid colors.$purple-light;
+        }
       }
     }
   }
@@ -250,6 +256,12 @@
     &:hover .ods-search-seasons__heading,
     &:focus .ods-search-seasons__heading {
       text-decoration: underline;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 0.125rem colors.$blue-state;
+      outline-offset: 0.125rem;
+      outline: 0.25rem solid colors.$purple-light;
     }
 
     &--divider {


### PR DESCRIPTION
Fikset outline på dropdown elementer

Vi har fortsatt et stort problem med footer-link i search circle og search seasons. Den delen av dropdownen &_item &-first og &-last bruker en padding. Den får keyboard navigasjonen til å se helt dust ut.

Har laget ny trello-sak på det (IO-1427). Må  kanskje fikses i forbindelse med link-oppdatering. 